### PR TITLE
Support loading images on the classpath

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,8 @@
   :dependencies [[org.clojure/clojure "1.5.1"]]
   :plugins [[lein-marginalia "0.7.1"]]
 
+  :profiles {:test {:resource-paths ["fixtures"]}}
+
   ;; :global-vars { *warn-on-reflection* true }
 
   ;; WebP support

--- a/src/fivetonine/collage/util.clj
+++ b/src/fivetonine/collage/util.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :refer [as-file file]])
   (:import java.io.File
            java.net.URI
+           java.net.URL
            java.awt.image.BufferedImage
            javax.imageio.ImageIO
            javax.imageio.IIOImage
@@ -66,6 +67,9 @@
 
   File
   (as-image [f] (ImageIO/read f))
+
+  URL
+  (as-image [r] (ImageIO/read r))
 
   BufferedImage
   (as-image [b] b))

--- a/test/fivetonine/collage/util_test.clj
+++ b/test/fivetonine/collage/util_test.clj
@@ -1,6 +1,7 @@
 (ns fivetonine.collage.util-test
   (:require [clojure.test :refer :all]
-            [clojure.java.io :refer [as-file]]
+            [clojure.java.io :refer [as-file resource]]
+            [clojure.string :as str]
             [fivetonine.collage.util :refer :all]
             [fivetonine.collage.helpers :refer :all])
   (:import java.io.File
@@ -25,7 +26,8 @@
     (are [image] (instance? BufferedImage image)
          (load-image path)
          (load-image (as-file path))
-         (load-image (ImageIO/read (as-file path))))))
+         (load-image (ImageIO/read (as-file path)))
+         (load-image (resource (str/replace path #"^fixtures/" ""))))))
 
 (deftest sanitize-path-test
   (is (instance? URI (sanitize-path "file:///path/to/some/image.png")))


### PR DESCRIPTION
ImageIO supports this out of the box, so all that is needed is adding it
to the protocol.

This allows images to be located on the classpath instead of through the
file system - as well as supporting images that reside in JARs.
